### PR TITLE
housekeeping: update github actions to v3

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,8 +28,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'


### PR DESCRIPTION
github will be removing key functionality in v2 by end of may so we need to update these actions. will keep this PR open for a short while to double check if I've missed anything