### PR TITLE
Fix darkmode (again?)

### DIFF
--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -62,6 +62,7 @@ $enable-validation-icons:     true;
 $enable-negative-margins:     true;
 $enable-deprecation-messages: true;
 $enable-important-utilities:  true;
+$enable-dark-mode:            true;
 
 /** Bootstrap navbar fix (https://git.io/fADqW) */
 $navbar-dark-toggler-icon-bg: none;

--- a/assets/scss/components/_alerts.scss
+++ b/assets/scss/components/_alerts.scss
@@ -15,8 +15,8 @@
 }
 
 .alert-doks {
-  background: $beige;
-  color: $black;
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-body-color);
 }
 
 /*
@@ -31,12 +31,12 @@
 */
 
 .alert-white {
-  background-color: rgba(255, 255, 255, 0.95);
+  background-color: var(--bs-body-bg);
 }
 
 .alert-primary {
-  color: $white;
-  background-color: $primary;
+  color: var(--bs-white);
+  background-color: var(--bs-primary);
 }
 
 .alert a {
@@ -157,7 +157,7 @@
 }
 
 .alert code {
-  background: darken($beige, 5%);
-  color: $black;
+  background: var(--bs-tertiary-bg);
+  color: var(--bs-body-color);
   padding: 0.25rem 0.5rem;
 }


### PR DESCRIPTION
I'm not quite sure if this solves the issue, but a long chat with Claude suggests we're missing this line: e88f13f

> This was the root cause: Without this setting, Bootstrap 5.3+ doesn't generate the CSS rules that update CSS variables like --bs-warning-bg-subtle when data-bs-theme="dark" is set.

Some troubleshooting points:
- The strange thing is everything works perfectly fine when deployed to localhost, which makes this kinda hard to test.
- The `data-bs-theme` attribute *does* correctly toggle on the deployed site
- I've also confirmed that both `darkmode-init.js` and `darkmode.js` in the published site are up to date, so it doesn't seem to be a caching problem with those files. 